### PR TITLE
Italics, Underline, and Strikethrough support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,6 @@ readme = "README.md"
 crossbeam-channel = "0.1.2"
 failure = "0.1.1"
 libc = "0.2.40"
-ransid = "0.4.6"
+ransid = { git = "https://github.com/E5ten/ransid" }
 termion = "1.5.1"
 structopt = "0.2.8"

--- a/src/main.rs
+++ b/src/main.rs
@@ -151,9 +151,11 @@ fn run(
             fn write_char(screen: &mut MyTerminal, c: RagerChar, x: usize, y: usize) {
                 // ::std::thread::sleep(::std::time::Duration::from_millis(1));
                 let _ = write!(screen,
-                    "{}{}{}{}{}",
+                    "{}{}{}{}{}{}{}",
                     termion::cursor::Goto((x as u16) + 1, (y as u16) + 1),
                     if c.1 { format!("{}", termion::style::Bold) } else { format!("") },
+                    if c.2 { format!("{}", termion::style::Underline) } else { format!("") },
+                    if c.3 { format!("{}", termion::style::Italic) } else { format!("") },
                     match c.4 {
                         ransid::color::Color::Ansi(c) => format!("{}", termion::color::Fg(termion::color::AnsiValue(c))),
                         ransid::color::Color::TrueColor(r, g, b) => format!("{}", termion::color::Fg(termion::color::Rgb(r, g, b))),

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,7 +37,7 @@ enum RagerEvent {
 
 
 #[derive(Copy, Clone)]
-struct RagerChar(char, bool, bool, bool, ransid::color::Color);
+struct RagerChar(char, bool, bool, bool, bool, ransid::color::Color);
 
 struct Buffer(usize, usize, RagerChar, Vec<Vec<RagerChar>>);
 
@@ -146,17 +146,18 @@ fn run(
         move || {
             let mut console = ransid::Console::new(screen_width, 32767);
 
-            let mut matrix = Buffer::new(screen_width, screen_height, RagerChar(' ', false, false, false, ransid::color::Color::Ansi(0)));
+            let mut matrix = Buffer::new(screen_width, screen_height, RagerChar(' ', false, false, false, false, ransid::color::Color::Ansi(0)));
 
             fn write_char(screen: &mut MyTerminal, c: RagerChar, x: usize, y: usize) {
                 // ::std::thread::sleep(::std::time::Duration::from_millis(1));
                 let _ = write!(screen,
-                    "{}{}{}{}{}{}{}",
+                    "{}{}{}{}{}{}{}{}",
                     termion::cursor::Goto((x as u16) + 1, (y as u16) + 1),
                     if c.1 { format!("{}", termion::style::Bold) } else { format!("") },
                     if c.2 { format!("{}", termion::style::Underline) } else { format!("") },
                     if c.3 { format!("{}", termion::style::Italic) } else { format!("") },
-                    match c.4 {
+                    if c.4 { format!("{}", termion::style::CrossedOut) } else { format!("") },
+                    match c.5 {
                         ransid::color::Color::Ansi(c) => format!("{}", termion::color::Fg(termion::color::AnsiValue(c))),
                         ransid::color::Color::TrueColor(r, g, b) => format!("{}", termion::color::Fg(termion::color::Rgb(r, g, b))),
                     },
@@ -178,9 +179,9 @@ fn run(
                 }
             };
 
-            let update = |screen: &mut MyTerminal, matrix: &mut Buffer, c, x, y, bold, underlined, italic, color| {
+            let update = |screen: &mut MyTerminal, matrix: &mut Buffer, c, x, y, bold, underlined, italic, strikethrough, color| {
                 
-                let c = RagerChar(c, bold, underlined, italic, color);
+                let c = RagerChar(c, bold, underlined, italic, strikethrough, color);
                 matrix.set(x, y, c);
                 
                 if y < (screen_height as usize) {
@@ -224,9 +225,10 @@ fn run(
                                         bold,
                                         underlined,
                                         italic,
+                                        strikethrough,
                                         color,
                                     } => {
-                                        update(screen, matrix, c, x, y, bold, underlined, italic, color);
+                                        update(screen, matrix, c, x, y, bold, underlined, italic, strikethrough, color);
                                     },
 
                                     // Ignore all other event types.

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,7 +37,7 @@ enum RagerEvent {
 
 
 #[derive(Copy, Clone)]
-struct RagerChar(char, bool, bool, ransid::color::Color);
+struct RagerChar(char, bool, bool, bool, ransid::color::Color);
 
 struct Buffer(usize, usize, RagerChar, Vec<Vec<RagerChar>>);
 
@@ -146,7 +146,7 @@ fn run(
         move || {
             let mut console = ransid::Console::new(screen_width, 32767);
 
-            let mut matrix = Buffer::new(screen_width, screen_height, RagerChar(' ', false, false, ransid::color::Color::Ansi(0)));
+            let mut matrix = Buffer::new(screen_width, screen_height, RagerChar(' ', false, false, false, ransid::color::Color::Ansi(0)));
 
             fn write_char(screen: &mut MyTerminal, c: RagerChar, x: usize, y: usize) {
                 // ::std::thread::sleep(::std::time::Duration::from_millis(1));
@@ -154,7 +154,7 @@ fn run(
                     "{}{}{}{}{}",
                     termion::cursor::Goto((x as u16) + 1, (y as u16) + 1),
                     if c.1 { format!("{}", termion::style::Bold) } else { format!("") },
-                    match c.3 {
+                    match c.4 {
                         ransid::color::Color::Ansi(c) => format!("{}", termion::color::Fg(termion::color::AnsiValue(c))),
                         ransid::color::Color::TrueColor(r, g, b) => format!("{}", termion::color::Fg(termion::color::Rgb(r, g, b))),
                     },
@@ -176,9 +176,9 @@ fn run(
                 }
             };
 
-            let update = |screen: &mut MyTerminal, matrix: &mut Buffer, c, x, y, bold, underlined, color| {
+            let update = |screen: &mut MyTerminal, matrix: &mut Buffer, c, x, y, bold, underlined, italic, color| {
                 
-                let c = RagerChar(c, bold, underlined, color);
+                let c = RagerChar(c, bold, underlined, italic, color);
                 matrix.set(x, y, c);
                 
                 if y < (screen_height as usize) {
@@ -221,9 +221,10 @@ fn run(
                                         c,
                                         bold,
                                         underlined,
+                                        italic,
                                         color,
                                     } => {
-                                        update(screen, matrix, c, x, y, bold, underlined, color);
+                                        update(screen, matrix, c, x, y, bold, underlined, italic, color);
                                     },
 
                                     // Ignore all other event types.


### PR DESCRIPTION
This switches rager to using my ransid fork and makes italics and underline support work. Fixes https://github.com/tcr/rager/issues/8