### PR TITLE
Change ransid back to upstream

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,6 @@ readme = "README.md"
 crossbeam-channel = "0.1.2"
 failure = "0.1.1"
 libc = "0.2.40"
-ransid = { git = "https://github.com/E5ten/ransid" }
+ransid = "0.4.7"
 termion = "1.5.1"
 structopt = "0.2.8"


### PR DESCRIPTION
Ransid upstream implemented the italics support that was previously in my fork so it can be used now.